### PR TITLE
simplification, fix to work for local testing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,6 @@ import os
 
 from dash import Dash
 from flask import Flask 
-from werkzeug.contrib.fixers import ProxyFix
 
 from .google_oauth import GoogleOAuth
 
@@ -14,8 +13,6 @@ app = Dash(
 	url_base_pathname='/',
 	auth='auth',
 )
-# use workzeug middleware to generate https callback
-server.wsgi_app = ProxyFix(server.wsgi_app)
 
 # configure google oauth using environment variables
 server.secret_key = os.environ.get("FLASK_SECRET_KEY", "supersekrit")
@@ -23,8 +20,7 @@ server.config["GOOGLE_OAUTH_CLIENT_ID"] = os.environ["GOOGLE_OAUTH_CLIENT_ID"]
 server.config["GOOGLE_OAUTH_CLIENT_SECRET"] = os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]
 
 # allow for insecure transport for local testing (remove in prod)
-server.config["OAUTHLIB_RELAX_TOKEN_SCOPE"] = 1
-server.config["OAUTHLIB_INSECURE_TRANSPORT"] = 1
+os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
 # designate list of authorized emails
 authorized_emails = [

--- a/app/auth.py
+++ b/app/auth.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 from six import iteritems, add_metaclass
 
-
 @add_metaclass(ABCMeta)
 class Auth(object):
     def __init__(self, app):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+dash==0.19.0
+dash_core_components==0.14.0
+dash_html_components==0.8.0
+flask==0.12
+flask_dance==0.14.0


### PR DESCRIPTION
- Removed werkzeug to keep the example simpler
- Added requirements
- Reconfigured oauth insecure transport as local environment variable rather than server environment variable. This allows for local testing without google complaining that oauth2 requires https