### PR TITLE
add optional additional scopes

### DIFF
--- a/app/google_oauth.py
+++ b/app/google_oauth.py
@@ -12,13 +12,13 @@ from flask_dance.contrib.google import (
 from .auth import Auth
 
 class GoogleOAuth(Auth):
-    def __init__(self, app, authorized_emails):
+    def __init__(self, app, authorized_emails, additional_scopes=None):
         super(GoogleOAuth, self).__init__(app)
         google_bp = make_google_blueprint(
             scope=[
                 "https://www.googleapis.com/auth/userinfo.email",
                 "https://www.googleapis.com/auth/userinfo.profile",
-            ],
+            ] + (additional_scopes if additional_scopes else []),
             offline=True,
             reprompt_consent=True,
         )


### PR DESCRIPTION
Allow additional scopes to be requested.

Useful to allow reusing credentials for things like:
```
...
from flask import session
from googleapiclient.discovery import build
from oauth2client.client import AccessTokenCredentials
...
@app.callback(...)
def update(...):

    credentials = AccessTokenCredentials(session['google_oauth_token']['access_token'], 'sheets')
    service = build('sheets', 'v4', credentials=credentials)
    ...
```