### PR TITLE
pin dash version before breaking auth change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dash>=0.26.5
+dash>=0.26.5,<1.0
 dash-core-components>=0.28.3
 dash-html-components>=0.12.0
 Flask>=0.12.4


### PR DESCRIPTION
**Context**
The Travis CI deploy is breaking after merging [PR-15](https://github.com/lchapo/dash-google-auth/pull/15) since Dash has changed quite a bit since the last deploy and no longer supports the `auth` argument upon instantiation (see [Travis log](https://travis-ci.org/github/lchapo/dash-google-auth/jobs/662200571))

**Change**
Pins the Dash version to before the breaking change

**Other**
This is a quick fix. Someone with more time is welcome to make this compatible with more recent versions of Dash.